### PR TITLE
Added mousemove event to allow label to follow cursor

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -103,6 +103,8 @@ L.UtfGrid = L.Class.extend({
 			}
 
 			this._mouseOn = on.data;
+		} else if (on.data) {
+			this.fire('mousemove', on);
 		}
 	},
 


### PR DESCRIPTION
I've added a mousemove event to allow hover labels to follow the cursor. Now, events are only fired when the cursour is entering/leaving an area. The new mousemove event will be fired when the user is moving the cursor within an area, allowing an update to the label position.

![label](https://f.cloud.github.com/assets/548708/123399/3246b7e0-6ebf-11e2-9244-8251c16178b7.png)
