### PR TITLE
Added cursor state change to grid hover

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -67,6 +67,7 @@ L.UtfGrid = L.Class.extend({
 
 	onAdd: function (map) {
 		this._map = map;
+		this._container = this._map._container;
 
 		this._update();
 
@@ -97,9 +98,11 @@ L.UtfGrid = L.Class.extend({
 		if (on.data !== this._mouseOn) {
 			if (this._mouseOn) {
 				this.fire('mouseout', { latlng: e.latlng, data: this._mouseOn });
+				this._container.style.cursor = '';
 			}
 			if (on.data) {
 				this.fire('mouseover', on);
+				this._container.style.cursor = 'pointer';
 			}
 
 			this._mouseOn = on.data;


### PR DESCRIPTION
So with the [mapbox.js](https://github.com/mapbox/mapbox.js), there is a cursor state change whenever you hover over an active part of the utfgrid. It's pretty nifty. It gives more indication of when you are interacting with something actionable. I've added that ability to Leaflet.utfgrid, using the same concepts as the Mapbox version.

It grabs the container of the map, and toggles the cursor style based on whether or not the the current grid hovers are firing (or not). Hope it works out!
