### PR TITLE
added L.UtfGrid class factory in Leaflet 0.4 style

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -231,3 +231,7 @@ L.UtfGrid = L.Class.extend({
 		return c - 32;
 	}
 });
+
+L.utfGrid = function(url, options) {
+	return new L.UtfGrid(url, options);
+};


### PR DESCRIPTION
In mid-2012, the Leaflet project [reworked how Leaflet objects can instantiated in the library](http://leafletjs.com/2012/07/30/leaflet-0-4-released.html), making the use of `new` optional.

I have added this style to Leaflet.utfgrid. Now, this:

```
var grid = new L.UtfGrid('http://{s}.tiles.mapbox.com/v3/...')
```

Can work like this, making chaining more feasible/pretty:

```
var grid = L.utfGrid('http://{s}.tiles.mapbox.com/v3/...')
```
