### PR TITLE
Reset cursor when layer is removed

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -88,6 +88,7 @@ L.UtfGrid = L.Class.extend({
 		map.off('click', this._click, this);
 		map.off('mousemove', this._move, this);
 		map.off('moveend', this._update, this);
+		this._map._container.style.cursor = '';
 	},
 
 	_click: function (e) {


### PR DESCRIPTION
This fixes a bug that occurs when you remove a layer with pointerCursor: true, and the cursor doesn't revert back.
