### PR TITLE
Own refactoring, breaks compatibility

### DIFF
--- a/example/map.html
+++ b/example/map.html
@@ -25,7 +25,7 @@
 			key: 'BC9A493B41014CAABB98F0471D759707'
 		});
 
-		var utfGrid = new L.UtfGrid('http://{s}.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.grid.json?callback={cb}');
+		var utfGrid = new L.UtfGridP('http://{s}.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.grid.json?callback={cb}');
 
 		utfGrid.on('click', function (e) {
 			if (e.data) {

--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -28,6 +28,9 @@ L.Util.ajax = function (url, cb) {
 	request.send();
 };
 L.UtfGrid = L.Class.extend({
+	// FIXME : L.GridLayer is not a complete asbtrasction of a
+	// tiling system and still assumes image tiles in some ways
+	// Tiling behavior should be abstracted out.
 	includes: L.Mixin.Events,
 	options: {
 		subdomains: 'abc',
@@ -38,115 +41,112 @@ L.UtfGrid = L.Class.extend({
 
 		resolution: 4,
 
-		useJsonP: true,
-		pointerCursor: true
+		pointerCursor: true,
 	},
 
-	//The thing the mouse is currently on
+	// The thing the mouse is currently on
 	_mouseOn: null,
+	// Tile data cache
+	_tiles: {},
 
 	initialize: function (url, options) {
-		L.Util.setOptions(this, options);
+		options = L.setOptions(this, options);
 
 		this._url = url;
-		this._cache = {};
 
-		//Find a unique id in window we can use for our callbacks
-		//Required for jsonP
-		var i = 0;
-		while (window['lu' + i]) {
-			i++;
-		}
-		this._windowKey = 'lu' + i;
-		window[this._windowKey] = {};
+		if (options.pointerCursor) this.on({
+			mouseover: this._pointerOn,
+			add: this._pointerOn,
+			mouseout: this._pointerOff,
+			remove: this._pointerOff,
+		}, this);
 
-		var subdomains = this.options.subdomains;
-		if (typeof this.options.subdomains === 'string') {
-			this.options.subdomains = subdomains.split('');
-		}
+		// FIXME : subdomains handling here is not DRY
+		// FIXME : too opinionated, not compatible with
+		// TileJSON's multiple source urls for example
+		if (typeof options.subdomains === 'string')
+			options.subdomains = options.subdomains.split('');
 	},
 
 	onAdd: function (map) {
 		this._map = map;
-		this._container = this._map._container;
+		this._map.on(this.getEvents(), this);
 
 		this._update();
 
-		var zoom = this._map.getZoom();
-
-		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
-			return;
-		}
-
-		map.on('click', this._click, this);
-		map.on('mousemove', this._move, this);
-		map.on('moveend', this._update, this);
+		this.fire('add');
 	},
 
 	onRemove: function () {
-		var map = this._map;
-		map.off('click', this._click, this);
-		map.off('mousemove', this._move, this);
-		map.off('moveend', this._update, this);
-		if (this.options.pointerCursor) {
-			this._container.style.cursor = '';
-		}
+		this.fire('remove');
+
+		this._map.off(this.getEvents(), this);
+		this._map = null;
 	},
 
+	getEvents: function() {
+		return {
+			click: this._click,
+			mousemove: this._move,
+			mouseout: this._out,
+			moveend: this._update,
+		};
+	},
+
+	_getTilePane: function () {
+		if (this._map) return this._map.getPanes().tilePane;
+	},
+
+	// Pointer cursor handlers
+	_pointerOn: function(e){
+		L.DomUtil.addClass( this._getTilePane(), 'leaflet-clickable');
+	},
+
+	_pointerOff: function(e){
+		L.DomUtil.removeClass( this._getTilePane(), 'leaflet-clickable');
+	},
+
+	// MouseEvents handlers
 	_click: function (e) {
-		this.fire('click', this._objectForEvent(e));
+		var data = this._getData(e.latlng);
+		this.fire('click', {latlng: e.latlng, data: data});
 	},
 	_move: function (e) {
-		var on = this._objectForEvent(e);
+		var data = this._getData(e.latlng);
 
-		if (on.data !== this._mouseOn) {
-			if (this._mouseOn) {
-				this.fire('mouseout', { latlng: e.latlng, data: this._mouseOn });
-				if (this.options.pointerCursor) {
-					this._container.style.cursor = '';
-				}
-			}
-			if (on.data) {
-				this.fire('mouseover', on);
-				if (this.options.pointerCursor) {
-					this._container.style.cursor = 'pointer';
-				}
-			}
-
-			this._mouseOn = on.data;
-		} else if (on.data) {
-			this.fire('mousemove', on);
+		if (data !== this._mouseOn) {
+			if (this._mouseOn) this._out(e);
+			if (data) this.fire('mouseover', {latlng: e.latlng, data: data});
+			this._mouseOn = data;
+		} else {
+			this.fire('mousemove', {latlng: e.latlng, data: data});
 		}
 	},
+	_out: function (e) {
+		this.fire('mouseout', null);
+		this._mouseOn = null;
+	},
 
-	_objectForEvent: function (e) {
+	_getData: function (latlng) {
 		var map = this._map,
-		    point = map.project(e.latlng),
-		    tileSize = this.options.tileSize,
-		    resolution = this.options.resolution,
-		    x = Math.floor(point.x / tileSize),
-		    y = Math.floor(point.y / tileSize),
-		    gridX = Math.floor((point.x - (x * tileSize)) / resolution),
-		    gridY = Math.floor((point.y - (y * tileSize)) / resolution),
+			point = map.project(latlng.wrap()),
+			tileSize = this.options.tileSize,
+			resolution = this.options.resolution,
+			x = Math.floor(point.x / tileSize),
+			y = Math.floor(point.y / tileSize),
 			max = map.options.crs.scale(map.getZoom()) / tileSize;
 
 		x = (x + max) % max;
 		y = (y + max) % max;
 
-		var data = this._cache[map.getZoom() + '_' + x + '_' + y];
-		if (!data || !data.grid) {
-			return { latlng: e.latlng, data: null };
-		}
+		var gridX = Math.floor((point.x - (x * tileSize)) / resolution),
+			gridY = Math.floor((point.y - (y * tileSize)) / resolution);
 
-		var idx = this._utfDecode(data.grid[gridY].charCodeAt(gridX)),
-		    key = data.keys[idx],
-		    result = data.data[key];
+		var key = this._getTileKey({z:map.getZoom(), x:x, y:y}),
+			data = this._tiles[key];
 
-		if (!data.data.hasOwnProperty(key)) {
-			result = null;
-		}
-
-		return { latlng: e.latlng, data: result};
+		if (typeof data === "function")
+			return L.bind(data, this)(gridX, gridY);
 	},
 
 	//Load up all required json grid files
@@ -154,95 +154,118 @@ L.UtfGrid = L.Class.extend({
 	_update: function () {
 
 		var bounds = this._map.getPixelBounds(),
-		    zoom = this._map.getZoom(),
-		    tileSize = this.options.tileSize;
+			zoom = this._map.getZoom(),
+			tileSize = this.options.tileSize,
+			max = this._map.options.crs.scale(zoom) / tileSize;
 
-		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
-			return;
-		}
+		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) return;
 
-		var nwTilePoint = new L.Point(
-				Math.floor(bounds.min.x / tileSize),
-				Math.floor(bounds.min.y / tileSize)),
-			seTilePoint = new L.Point(
-				Math.floor(bounds.max.x / tileSize),
-				Math.floor(bounds.max.y / tileSize)),
-				max = this._map.options.crs.scale(zoom) / tileSize;
+		bounds = L.bounds(
+					bounds.min.divideBy(tileSize).floor(),
+					bounds.max.divideBy(tileSize).floor());
 
-		//Load all required ones
-		for (var x = nwTilePoint.x; x <= seTilePoint.x; x++) {
-			for (var y = nwTilePoint.y; y <= seTilePoint.y; y++) {
+		for (var x = bounds.min.x; x <= bounds.max.x; x++) {
+			for (var y = bounds.min.y; y <= bounds.max.y; y++) {
+				var coords = {
+						x: (x + max) % max,
+						y: (y + max) % max,
+						z: zoom
+					},
+					key = this._getTileKey(coords);
 
-				var xw = (x + max) % max, yw = (y + max) % max;
-				var key = zoom + '_' + xw + '_' + yw;
-
-				if (!this._cache.hasOwnProperty(key)) {
-					this._cache[key] = null;
-
-					if (this.options.useJsonP) {
-						this._loadTileP(zoom, xw, yw);
-					} else {
-						this._loadTile(zoom, xw, yw);
-					}
+				if (!this._tiles.hasOwnProperty(key)) {
+					this._tiles[key] = null;
+					this._loadTile(coords, this._cacheData(key));
 				}
 			}
 		}
 	},
 
-	_loadTileP: function (zoom, x, y) {
-		var head = document.getElementsByTagName('head')[0],
-		    key = zoom + '_' + x + '_' + y,
-		    functionName = 'lu_' + key,
-		    wk = this._windowKey,
-		    self = this;
-
-		var url = L.Util.template(this._url, L.Util.extend({
-			s: L.TileLayer.prototype._getSubdomain.call(this, { x: x, y: y }),
-			z: zoom,
-			x: x,
-			y: y,
-			cb: wk + '.' + functionName
-		}, this.options));
-
-		var script = document.createElement('script');
-		script.setAttribute("type", "text/javascript");
-		script.setAttribute("src", url);
-
-		window[wk][functionName] = function (data) {
-			self._cache[key] = data;
-			delete window[wk][functionName];
-			head.removeChild(script);
-		};
-
-		head.appendChild(script);
+	_cacheData: function(key) {
+		return L.bind(function (data) {
+			this._tiles[key] = this._gridData(data);
+		}, this);
 	},
 
-	_loadTile: function (zoom, x, y) {
-		var url = L.Util.template(this._url, L.Util.extend({
-			s: L.TileLayer.prototype._getSubdomain.call(this, { x: x, y: y }),
-			z: zoom,
-			x: x,
-			y: y
-		}, this.options));
+	_getTileKey: function (coords) {
+		// valid property name
+		// NOTE : leaflet choses not to use z
+		return L.Util.template("tile_{z}_{x}_{y}", coords);
+	},
 
-		var key = zoom + '_' + x + '_' + y;
-		var self = this;
-		L.Util.ajax(url, function (data) {
-			self._cache[key] = data;
+	_getTileUrl: function(options) {
+		options = L.extend({
+			s: L.TileLayer.prototype._getSubdomain.call(this, options),
+			}, options);
+		options = L.extend(options, this.options);
+		options = L.extend(options, {
 		});
+		return L.Util.template(this._url, options);
+	},
+
+	// actually fetch the tile
+	_loadTile: function(coords, callback) {
+		L.Util.ajax(this._getTileUrl(coords), cb);
+	},
+
+	// UTFGrid data handling
+	_gridData: function (data) {
+		return function (x,y){
+			if (!data || !data.grid) return;
+			var idx = this._utfDecode(data.grid[y].charCodeAt(x)),
+				key = data.keys[idx];
+			return data.data[key];
+		};
 	},
 
 	_utfDecode: function (c) {
-		if (c >= 93) {
-			c--;
-		}
-		if (c >= 35) {
-			c--;
-		}
+		if (c >= 93) c--;
+		if (c >= 35) c--;
 		return c - 32;
 	}
 });
 
 L.utfGrid = function (url, options) {
 	return new L.UtfGrid(url, options);
+};
+
+/* UtfGrid with JSONP */
+L.UtfGridP = L.UtfGrid.extend({
+	statics: {
+		_cb:{},
+	},
+
+	initialize: function (url, options) {
+		options = L.setOptions(this, options);
+		L.UtfGrid.prototype.initialize.call(this, url, options);
+
+		this.gridName = options.gridName ? options.gridName : "grid_"+L.stamp(this);
+		L.UtfGridP._cb[this.gridName] = this._callbacks = {};
+	},
+
+	_loadTile: function (coords, callback) {
+		var key = this._getTileKey(coords),
+			cb = L.Util.template("L.UtfGridP._cb.{gridName}.{tileKey}",
+				{gridName: this.gridName,tileKey: key}),
+			options = L.Util.extend({cb: cb}, coords),
+			url = this._getTileUrl(options);
+
+		var head = document.getElementsByTagName('head')[0],
+			script = document.createElement('script');
+
+		script.setAttribute("type", "text/javascript");
+		script.setAttribute("src", url);
+
+		this._callbacks[key] = L.bind(function (data) {
+			callback(data);
+			delete this._callbacks[key];
+			head.removeChild(script);
+		}, this);
+
+		head.appendChild(script);
+	},
+});
+
+L.utfGridP = function (url, options) {
+	return new L.UtfGridP(url, options);
 };


### PR DESCRIPTION
Hello there, I've been working with leaflet.utfgrid and stacked up a bit of refactoring, it's quite too big to merge as is, but you might still want to take a look.

Commented commit message follows :

The main item in my refactoring is the split of the two available loading behaviors in two classes, with XHR as sane default an JSONP being the overriding.
It extracts the JSONP/callbacks specific code from the base class, which is nice.

```
 On XHR vs JSONP:
 - L.UtfGrid defaults to XHR (sane default policy)
 - Implement JSONP behavior in a child class : L.UtfGridP
 - JSONP callbacks now have predictable names (set gridName option)
   cb name pattern : L.UtfGridP._cb.{gridName}.tile_{z}_{x}_{y}(...)
```

A bit of refactoring on events handling, from Leaflet I borrow getEvents and add a few ones

```
Add "add", "remove" layer events.
Fire "mouseout" on map's mouseout.
```

On pointerCursor, attaching the behavior to the map's tilePane makes more sense to me.
Use the grid's events to tidy up the code and leaflet's css for consistency.

```
Re-implement pointerCursor behavior:
 - bind to events from this (tidy up code)
 - use leaflet-clickable css class on tilePane
```

```
Cherry-pick some code improvements from Mapbox and Leaflet.
```
