### PR TITLE
Add public redraw function

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -93,6 +93,12 @@ L.UtfGrid = L.Class.extend({
 		}
 	},
 
+    redraw: function () {
+        // Clear cache to force all tiles to reload
+        this._cache = {};
+        this._update();
+    },
+
 	_click: function (e) {
 		this.fire('click', this._objectForEvent(e));
 	},


### PR DESCRIPTION
Clears cache and re-fetches tiles
Useful if the utfgrid template URL depends on more than x/y/z
