### PR TITLE
Implemented a queue for the tile requests (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ var utfGrid = new L.UtfGrid('http://myserver/amazingness/{z}/{x}/{y}.grid.json',
 
 ### Other options
 
-pointerCursor: changes the mouse cursor to a pointer when hovering over an interactive part of the grid. (Default: true)
+- pointerCursor: changes the mouse cursor to a pointer when hovering over an interactive part of the grid. (Default: true)
+- maxRequests: Maximum number of requests sent at once to the utfgrid tile server. Increasing this will get more processing done at once, however it means your utfgrid tiles will get priority over your visual tiles (as browsers tend to prioritize javascript/json requests). Increasing this will also reduce the number of requests that may get dropped early when users pan the map. There is little point to have this higher than 8.  (Default: 4)
+- requestTimeout: number of milliseconds after which a request for a tile is considered to have timed out. (Default: 60000)
 
 ### Turning interaction on and off
 

--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -26,6 +26,7 @@ L.Util.ajax = function (url, cb) {
 		}
 	};
 	request.send();
+	return request;
 };
 L.UtfGrid = L.Class.extend({
 	includes: L.Mixin.Events,
@@ -39,11 +40,19 @@ L.UtfGrid = L.Class.extend({
 		resolution: 4,
 
 		useJsonP: true,
-		pointerCursor: true
+		pointerCursor: true,
+
+		maxRequests: 4,
+		requestTimeout: 60000
 	},
 
 	//The thing the mouse is currently on
 	_mouseOn: null,
+
+	// The requests
+	_requests: {},
+	_request_queue: [],
+	_requests_in_process: [],
 
 	initialize: function (url, options) {
 		L.Util.setOptions(this, options);
@@ -93,11 +102,17 @@ L.UtfGrid = L.Class.extend({
 		}
 	},
 
-    redraw: function () {
-        // Clear cache to force all tiles to reload
-        this._cache = {};
-        this._update();
-    },
+	redraw: function () {
+		// Clear cache to force all tiles to reload
+		this._request_queue = [];
+		for (var req_key in this._requests){
+			if (this._requests.hasOwnProperty(req_key)){
+				this._abort_request(req_key);
+			}
+		}
+		this._cache = {};
+		this._update();
+	},
 
 	_click: function (e) {
 		this.fire('click', this._objectForEvent(e));
@@ -176,11 +191,13 @@ L.UtfGrid = L.Class.extend({
 				max = this._map.options.crs.scale(zoom) / tileSize;
 
 		//Load all required ones
+		var visible_tiles = [];
 		for (var x = nwTilePoint.x; x <= seTilePoint.x; x++) {
 			for (var y = nwTilePoint.y; y <= seTilePoint.y; y++) {
 
 				var xw = (x + max) % max, yw = (y + max) % max;
 				var key = zoom + '_' + xw + '_' + yw;
+				visible_tiles.push(key);
 
 				if (!this._cache.hasOwnProperty(key)) {
 					this._cache[key] = null;
@@ -191,6 +208,12 @@ L.UtfGrid = L.Class.extend({
 						this._loadTile(zoom, xw, yw);
 					}
 				}
+			}
+		}
+		// If we still have requests for tiles that have now gone out of sight, attempt to abort them.
+		for (var req_key in this._requests){
+			if (visible_tiles.indexOf(req_key) < 0){
+				this._abort_request(req_key);
 			}
 		}
 	},
@@ -218,9 +241,17 @@ L.UtfGrid = L.Class.extend({
 			self._cache[key] = data;
 			delete window[wk][functionName];
 			head.removeChild(script);
+			self._finish_request(key);
 		};
 
-		head.appendChild(script);
+		this._queue_request(key, function(){
+			head.appendChild(script);
+			return {
+				abort: function(){
+					head.removeChild(script);
+				}
+			};
+		});
 	},
 
 	_loadTile: function (zoom, x, y) {
@@ -233,9 +264,79 @@ L.UtfGrid = L.Class.extend({
 
 		var key = zoom + '_' + x + '_' + y;
 		var self = this;
-		L.Util.ajax(url, function (data) {
-			self._cache[key] = data;
+		this._queue_request(key, function(){
+			return L.Util.ajax(url, function (data) {
+				self._cache[key] = data;
+				self._finish_request(key);
+			});
 		});
+	},
+
+	_queue_request: function(key, callback){
+		this._requests[key] = {
+			callback: callback,
+			timeout: null,
+			handler: null
+		};
+		this._request_queue.push(key);
+		this._process_queued_requests();
+	},
+
+	_finish_request: function(key){
+		// Remove from requests in process
+		var pos = this._requests_in_process.indexOf(key);
+		if (pos >= 0) {
+			this._requests_in_process.splice(pos, 1);
+		}
+		// Remove from request queue
+		pos = this._request_queue.indexOf(key);
+		if (pos >= 0){
+			this._request_queue.splice(pos, 1);
+		}
+		// Remove the request entry
+		if (this._requests[key]) {
+			if (this._requests[key].timeout) {
+				window.clearTimeout(this._requests[key].timeout);
+			}
+			delete this._requests[key];
+		}
+		// Recurse
+		this._process_queued_requests();
+	},
+
+	_abort_request: function(key){
+		// Abort the request if possible
+		if (this._requests[key] && this._requests[key].handler){
+			if (typeof this._requests[key].handler.abort === 'function'){
+				this._requests[key].handler.abort();
+			}
+		}
+		// Ensure we don't keep a false copy of the data in the cache
+		if (this._cache[key] === null){
+			delete this._cache[key];
+		}
+		// And remove the request
+		this._finish_request(key);
+	},
+
+	_process_queued_requests: function() {
+		while (this._request_queue.length > 0 && (this.options.maxRequests === 0 ||
+		       this._requests_in_process.length < this.options.maxRequests)){
+			this._process_request(this._request_queue.pop());
+		}
+	},
+
+	_process_request: function(key){
+		var self = this;
+		this._requests[key].timeout = window.setTimeout(function(){
+			self._abort_request(key);
+		}, this.options.requestTimeout);
+		this._requests_in_process.push(key);
+		// The callback might call _finish_request, so don't assume _requests[key] still exists.
+		var handler = this._requests[key].callback();
+		if (this._requests[key]){
+			this._requests[key].handler = handler;
+		}
 	},
 
 	_utfDecode: function (c) {


### PR DESCRIPTION
Hello,

Here is an implementation of a queue for tile requests. I have re-generated the files in `dist/` only to notice they were not in sync with the code in `src/` ! So when looking at the diffs, check the diffs with the file in `src/`.

Motivation for the implementation:
- Limit the number of requests sent at once. Browsers prioritize javascript/json requests, so in my use cases the visual tiles did not get loaded until all the utfgrid tiles were loaded. When these take a non-trivial time to generate, this delays the visual tiles noticeably. Chrome/FF send at most 8 concurrent requests by default (not sure about IE), so I have set this to a (configurable) default of 4 concurrent utfgrid requests. This ensures that there is 4 available slots for image tiles;
- Cancel loading requests. By limiting the number of concurrent requests, we can also ensure that if a tile has gone out of view before it even started loading then we can simply drop it from the queue. My implementation also cancels loading tiles after the ajax request was made. In Chrome, this works for JSON tiles but not JSON-P tiles. This provides an additional performance boost if the tile server detects dropped connections (not a trivial problem. I assume many won't; but the one I implemented for this project does if the connection gets dropped while in the server queue).

Implementation notes:
- Rather than directly sending the requests, `_loadTileP` and `_loadTile` call `_queue_request` to add the request to the queue. `_queue_request` is called with the key of the tile (ie. `<z>_<x>_<y>`) and a function to be called when the request should be initiated. The function should return an object that has an `abort` method, that can be used to cancel requests;
- Request callbacks must invoke `_finish_request(key)`;
- Requests are stored as objects in `_request`, indexed by the request key. The request object defines:
  - `callback`, the function that is called to start the actual request;
  - `handler`, the object returned by the callback function ;
  - `timeout`, a timeout id used to track request timeouts. The timeout starts when the request is initiated, and will abort the request if triggered before `_finish_request` is called.
- Every time a new request is added, and every time a request finishes or is aborted (via timeout or by being moved out of view) `_process_queued_requests` is called. This ensures that we are always processing as many requests as possible (and no request is left un-processed);
- The queue is filo queue. As users pan the map, newer requests are likely to be more important, while older requests are more likely to get dropped.
