### PR TITLE
Add public setUrl() function

### DIFF
--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -102,6 +102,16 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		}
 	},
 
+	setUrl: function (url, noRedraw) {
+		this._url = url;
+		
+		if (!noRedraw) {
+			this.redraw();
+		}
+		
+		return this;
+	},
+
 	redraw: function () {
 		// Clear cache to force all tiles to reload
 		this._request_queue = [];


### PR DESCRIPTION
Change the URL and redraw the layer. 
setUrl() copied from L.TileLayer and working after changes in #31.
Tested with Leaflet 0.7.3 and 0.8