### PR TITLE
Add bower.json for bower functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "Leaflet.utfgrid",
+  "main": "dist/leaflet.utfgrid.js",
+  "ignore": [
+    "build",
+    "src",
+    ".gitignore",
+    "Jakefile.js"
+  ],
+  "dependencies": {
+    "leaflet": "~0.7.3"
+  }
+}


### PR DESCRIPTION
This allows consumption of Leaflet.utfgrid via Bower; whether to register it in https://github.com/bower/registry feels optional, but I'm OK linking to the GitHub URL too.