### PR TITLE
Expose original mouse event

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1,9 +1,13 @@
 var build = require('./build/build.js'),
     lint = require('./build/hint.js');
 
-var COPYRIGHT = '/*\n Copyright (c) 2012, Smartrak, David Leaver\n' +
-                ' Leaflet.utfgrid is an open-source JavaScript library that provides utfgrid interaction on leaflet powered maps.\n' + 
-                ' https://github.com/danzel/Leaflet.utfgrid\n*/\n';
+var COPYRIGHT = '/*!\n' +
+                ' * Copyright (c) 2012, Smartrak, David Leaver\n' +
+                ' * Leaflet.utfgrid is an open-source JavaScript library that provides utfgrid interaction on leaflet powered maps.\n' + 
+                ' * https://github.com/danzel/Leaflet.utfgrid\n' +
+                ' *\n' +
+                ' * @license MIT\n' +
+                ' */\n';
 
 desc('Check Leaflet.utfgrid source for errors with JSHint');
 task('lint', function () {

--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -115,8 +115,8 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 	redraw: function () {
 		// Clear cache to force all tiles to reload
 		this._request_queue = [];
-		for (var req_key in this._requests){
-			if (this._requests.hasOwnProperty(req_key)){
+		for (var req_key in this._requests) {
+			if (this._requests.hasOwnProperty(req_key)) {
 				this._abort_request(req_key);
 			}
 		}
@@ -219,8 +219,8 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 			}
 		}
 		// If we still have requests for tiles that have now gone out of sight, attempt to abort them.
-		for (var req_key in this._requests){
-			if (visible_tiles.indexOf(req_key) < 0){
+		for (var req_key in this._requests) {
+			if (visible_tiles.indexOf(req_key) < 0) {
 				this._abort_request(req_key);
 			}
 		}
@@ -252,10 +252,10 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 			self._finish_request(key);
 		};
 
-		this._queue_request(key, function(){
+		this._queue_request(key, function() {
 			head.appendChild(script);
 			return {
-				abort: function(){
+				abort: function() {
 					head.removeChild(script);
 				}
 			};
@@ -272,7 +272,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 
 		var key = zoom + '_' + x + '_' + y;
 		var self = this;
-		this._queue_request(key, function(){
+		this._queue_request(key, function() {
 			return L.Util.ajax(url, function (data) {
 				self._cache[key] = data;
 				self._finish_request(key);
@@ -280,7 +280,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		});
 	},
 
-	_queue_request: function(key, callback){
+	_queue_request: function(key, callback) {
 		this._requests[key] = {
 			callback: callback,
 			timeout: null,
@@ -290,7 +290,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		this._process_queued_requests();
 	},
 
-	_finish_request: function(key){
+	_finish_request: function(key) {
 		// Remove from requests in process
 		var pos = this._requests_in_process.indexOf(key);
 		if (pos >= 0) {
@@ -298,7 +298,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		}
 		// Remove from request queue
 		pos = this._request_queue.indexOf(key);
-		if (pos >= 0){
+		if (pos >= 0) {
 			this._request_queue.splice(pos, 1);
 		}
 		// Remove the request entry
@@ -316,15 +316,15 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		}
 	},
 
-	_abort_request: function(key){
+	_abort_request: function(key) {
 		// Abort the request if possible
-		if (this._requests[key] && this._requests[key].handler){
-			if (typeof this._requests[key].handler.abort === 'function'){
+		if (this._requests[key] && this._requests[key].handler) {
+			if (typeof this._requests[key].handler.abort === 'function') {
 				this._requests[key].handler.abort();
 			}
 		}
 		// Ensure we don't keep a false copy of the data in the cache
-		if (this._cache[key] === null){
+		if (this._cache[key] === null) {
 			delete this._cache[key];
 		}
 		// And remove the request
@@ -333,20 +333,20 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 
 	_process_queued_requests: function() {
 		while (this._request_queue.length > 0 && (this.options.maxRequests === 0 ||
-		       this._requests_in_process.length < this.options.maxRequests)){
+		       this._requests_in_process.length < this.options.maxRequests)) {
 			this._process_request(this._request_queue.pop());
 		}
 	},
 
-	_process_request: function(key){
+	_process_request: function(key) {
 		var self = this;
-		this._requests[key].timeout = window.setTimeout(function(){
+		this._requests[key].timeout = window.setTimeout(function() {
 			self._abort_request(key);
 		}, this.options.requestTimeout);
 		this._requests_in_process.push(key);
 		// The callback might call _finish_request, so don't assume _requests[key] still exists.
 		var handler = this._requests[key].callback();
-		if (this._requests[key]){
+		if (this._requests[key]) {
 			this._requests[key].handler = handler;
 		}
 	},

--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -49,13 +49,13 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 	//The thing the mouse is currently on
 	_mouseOn: null,
 
-	// The requests
-	_requests: {},
-	_request_queue: [],
-	_requests_in_process: [],
-
 	initialize: function (url, options) {
 		L.Util.setOptions(this, options);
+
+		// The requests
+		this._requests = {};
+		this._request_queue = [];
+		this._requests_in_process = [];
 
 		this._url = url;
 		this._cache = {};
@@ -165,19 +165,17 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 		y = (y + max) % max;
 
 		var data = this._cache[map.getZoom() + '_' + x + '_' + y];
-		if (!data || !data.grid) {
-			return { latlng: e.latlng, data: null };
+		var result = null;
+		if (data && data.grid) {
+			var idx = this._utfDecode(data.grid[gridY].charCodeAt(gridX)),
+				key = data.keys[idx];
+
+			if (data.data.hasOwnProperty(key)) {
+				result = data.data[key];
+			}
 		}
 
-		var idx = this._utfDecode(data.grid[gridY].charCodeAt(gridX)),
-		    key = data.keys[idx],
-		    result = data.data[key];
-
-		if (!data.data.hasOwnProperty(key)) {
-			result = null;
-		}
-
-		return { latlng: e.latlng, data: result};
+		return L.extend({ latlng: e.latlng, data: result }, e);
 	},
 
 	//Load up all required json grid files


### PR DESCRIPTION
Make Leaflet.utfgrid events extend the original events

* This enables fetching other event-related metadata, like Ctrl/Shift modifier keys, off of the UtfGrid mouse event.
* Also did a drive-by fix of a non-primitive-on-class-prototype bug, which causes multiple UtfGrid instances to share the same request queue, causing some grids to lose tiles.
* Modified license comment to include @license annotation for better preservation by other dist-building tools. Wanted to have the uglifyjs version here do the same, but the current version is too old and didn't want to change the setup too much...
* Rebuilt dist from source updates? Not sure if this should be done now or at new version/release time.