### PR TITLE
Update build.js

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -55,7 +55,7 @@ exports.combineFiles = function (files) {
 	for (var i = 0, len = files.length; i < len; i++) {
 		content += fs.readFileSync(files[i], 'utf8') + '\n\n';
 	}
-	return content + '\n\n}(this));';
+	return content + '\n\n}(window));';
 };
 
 exports.save = function (savePath, compressed) {


### PR DESCRIPTION
I've updated the build.js file so the classes are initialized with 'window' instead of 'this' . I didn't build /dist cause I assume you prefer to do that according to the discussion in issue #28 (I wasn't able to get the jake build task to run without error anyhow). 

thanks,
Greg