### PR TITLE
some modernization

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -3,7 +3,7 @@ var build = require('./build/build.js'),
 
 var COPYRIGHT = '/*!\n' +
                 ' * Copyright (c) 2012, Smartrak, David Leaver\n' +
-                ' * Leaflet.utfgrid is an open-source JavaScript library that provides utfgrid interaction on leaflet powered maps.\n' + 
+                ' * Leaflet.utfgrid is an open-source JavaScript library that provides utfgrid interaction on leaflet powered maps.\n' +
                 ' * https://github.com/danzel/Leaflet.utfgrid\n' +
                 ' *\n' +
                 ' * @license MIT\n' +
@@ -52,7 +52,6 @@ task('build', ['lint'], function (compsBase32, buildName) {
 	}
 
 	console.log('Compressing...');
-
 	var path = pathPart + '.js',
 	    oldCompressed = build.load(path),
 	    newCompressed = COPYRIGHT + build.uglify(content),

--- a/build/build.js
+++ b/build/build.js
@@ -33,7 +33,7 @@ exports.getFiles = function (compsBase32) {
 	var files = [];
 
 	for (var src in memo) {
-		files.push('src/' + src);
+		files.push('./src/' + src);
 	}
 
 	return files;
@@ -41,13 +41,10 @@ exports.getFiles = function (compsBase32) {
 
 exports.uglify = function (code) {
 	var pro = uglifyjs.uglify;
-
-	var ast = uglifyjs.parser.parse(code);
-	ast = pro.ast_mangle(ast, {mangle: true});
-	ast = pro.ast_squeeze(ast);
-	ast = pro.ast_squeeze_more(ast);
-
-	return pro.gen_code(ast) + ';';
+	return uglifyjs.minify(code, {
+		fromString: true,
+		mangle: true
+	}).code + ';'
 };
 
 exports.combineFiles = function (files) {

--- a/example/layers.html
+++ b/example/layers.html
@@ -3,12 +3,12 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+	<link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+	<script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<script src="../src/leaflet.utfgrid.js"></script>
+	<script src="../dist/leaflet.utfgrid.js"></script>
 </head>
 <body>
 
@@ -16,7 +16,7 @@
 	Use the layers dialog to turn interaction on and off.
 	<div id="click"></div>
 	<div id="hover"></div>
-	
+
 	<script type="text/javascript">
 
 		var tiles = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
@@ -30,15 +30,15 @@
 		});
 
 		var utfGrid = new L.UtfGrid('http://{s}.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.grid.json?callback={cb}');
-		
+
 		//Use a LayerGroup to group together a TileLayer and our UtfGrid layer
 		//This enables us to toggle them both together in the layers dialog
 		var interactiveLayerGroup = L.layerGroup([
 			tiles2,
 			utfGrid
 		]);
-		
-		
+
+
 		//Events
 		utfGrid.on('click', function (e) {
 			if (e.data) {
@@ -46,7 +46,7 @@
 			} else {
 				document.getElementById('click').innerHTML = 'click: nothing';
 			}
-		}); 
+		});
 		utfGrid.on('mouseover', function (e) {
 			if (e.data) {
 				document.getElementById('hover').innerHTML = 'hover: ' + e.data.admin;

--- a/example/map-ajax.html
+++ b/example/map-ajax.html
@@ -3,12 +3,12 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+	<link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+	<script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<script src="../src/leaflet.utfgrid.js"></script>
+	<script src="../dist/leaflet.utfgrid-src.js"></script>
 </head>
 <body>
 
@@ -33,7 +33,7 @@
 			} else {
 				document.getElementById('click').innerHTML = 'click: nothing';
 			}
-		}); 
+		});
 		utfGrid.on('mouseover', function (e) {
 			if (e.data) {
 				document.getElementById('hover').innerHTML = 'hover: ' + e.data.admin;

--- a/example/map.html
+++ b/example/map.html
@@ -3,12 +3,12 @@
 <head>
 	<title>Leaflet debug page</title>
 
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+	<link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+	<script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<script src="../src/leaflet.utfgrid.js"></script>
+	<script src="../dist/leaflet.utfgrid-src.js"></script>
 </head>
 <body>
 
@@ -31,7 +31,7 @@
 			} else {
 				document.getElementById('click').innerHTML = 'click: nothing';
 			}
-		}); 
+		});
 		utfGrid.on('mouseover', function (e) {
 			if (e.data) {
 				document.getElementById('hover').innerHTML = 'hover: ' + e.data.admin;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "leaflet.utfgrid",
+  "version": "1.0.0",
+  "description": "Leaflet.utfgrid ===============",
+  "main": "dist/leaflet.utfgrid-src.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "jake"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danzel/Leaflet.utfgrid.git"
+  },
+  "keywords": [
+    "leaflet",
+    "utf",
+    "grid",
+    "map"
+  ],
+  "author": "Calvin W. Metcalf <calvin.metcalf@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/danzel/Leaflet.utfgrid/issues"
+  },
+  "homepage": "https://github.com/danzel/Leaflet.utfgrid#readme",
+  "devDependencies": {
+    "jake": "^8.0.12",
+    "jshint": "^2.8.0",
+    "leaflet": "^1.0.0-beta.1",
+    "uglify-js": "^2.4.24"
+  }
+}

--- a/src/leaflet.utfgrid.js
+++ b/src/leaflet.utfgrid.js
@@ -1,30 +1,25 @@
 L.Util.ajax = function (url, success, error) {
-	// the following is from JavaScript: The Definitive Guide
-	// and https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
 	if (window.XMLHttpRequest === undefined) {
-		window.XMLHttpRequest = function () {
-			/*global ActiveXObject:true */
-			try {
-				return new ActiveXObject("Microsoft.XMLHTTP");
-			}
-			catch  (e) {
-				throw new Error("XMLHttpRequest is not supported");
-			}
-		};
+		error(new Error("XMLHttpRequest is not supported"));
 	}
 	var response, request = new XMLHttpRequest();
 	request.open("GET", url);
 	request.onreadystatechange = function () {
-		/*jshint evil: true */
 		if (request.readyState === 4) {
 			if (request.status === 200) {
 				if (window.JSON) {
-					response = JSON.parse(request.responseText);
+					try {
+						response = JSON.parse(request.responseText);
+						success(response);
+					} catch(e) {
+						error(e);
+					}
 				} else {
-					response = eval("(" + request.responseText + ")");
+					error(new Error('json not supported'));
 				}
-				success(response);
-			} else if (request.status !== 0 && error !== undefined) {
+			} else if (!request.status) {
+				error('Attempted cross origin request without CORS enabled');
+			} else {
 				error(request.status);
 			}
 		}


### PR DESCRIPTION
does 2 things in 2 commits, and I can revert the 2nd one if need be

1. removes the legacy support for browsers that don't support XHR and JSON.parse, on the grounds that leaflet doesn't actually support.  It was probably unnecessary when it was put in (by me) and all it will likely do is cause security errors.   This should also handle errors due to cors issues better now (they have status of 0).
2. added a package.json for dependency management, I.E. to run the build without having to globally install jake, uglify and jshint, this also fixes the uglify-js code to work with the more recent version and changes the examples to point the the dist folder and to use the most recent leaflet code to enable me to test change 1.  This change can be reverted.