### PR TITLE
Zoom rounding. Leaflet map zoom is sometimes fractional, e.g. during …

### DIFF
--- a/dist/leaflet.utfgrid-src.js
+++ b/dist/leaflet.utfgrid-src.js
@@ -95,7 +95,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 
 		this._update();
 
-		var zoom = this._map.getZoom();
+		var zoom = Math.round(this._map.getZoom());
 
 		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
 			return;
@@ -197,7 +197,7 @@ L.UtfGrid = (L.Layer || L.Class).extend({
 	_update: function () {
 
 		var bounds = this._map.getPixelBounds(),
-		    zoom = this._map.getZoom(),
+		    zoom = Math.round(this._map.getZoom()),
 		    tileSize = this.options.tileSize;
 
 		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {


### PR DESCRIPTION
…FlyTo animation, at least in the 1.0 beta 2. This was creating requests during the animation like:

http://localhost:3000/tiles/1/20.777261324503318/1023650/520273.grid.json?callback=lu0.lu_20.777261324503318_1023650_520273

This fix simply rounds the map zoom level.